### PR TITLE
Have only one deployment job now

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -59,12 +59,17 @@ jobs:
       - name: Set target environment
         run: |
           if [[ "${{ github.event_name }}" == "push" && "${{ github.ref_name }}" == "dev" ]]; then
-            echo "environment=DEV" >> $GITHUB_ENV
+            echo "environment=dev" >> $GITHUB_ENV
           fi
+        shell: bash
+          
+      - name: Print github variables
+        run: echo ${{ env.environment }}
+        shell: bash
       
       - name: Use local deploy-to-cloud-hub action
         uses: ./.github/actions/deploy-to-cloud-hub
         with:
           username: ${{ secrets.ANYPOINT_PLATFORM_USERNAME }}
           password: ${{ secrets.ANYPOINT_PLATFORM_PASSWORD }}
-          environment: "$environment"
+          environment: ${{ env.environment }}

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -56,18 +56,12 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Set DEV environment
-        uses: actions/cache@v4
-        if: github.event_name == 'push' && github.ref_name == 'dev'
-        env:
-          environment: dev
+      - name: Set target environment
+        run: |
+          if [[ "${{ github.event_name }}" == "push" && "${{ github.ref_name }}" == "dev" ]]; then
+            echo "environment=DEV" >> $GITHUB_ENV
+          fi
       
-      - name: Set QA environment
-        uses: actions/cache@v4
-        if: github.event.pull_request.merged == true && github.ref_name == 'qa'
-        env:
-          environment: qa
-
       - name: Use local deploy-to-cloud-hub action
         uses: ./.github/actions/deploy-to-cloud-hub
         with:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -49,33 +49,24 @@ jobs:
           path: target/*.jar
 
   # Runs this job with each new commit pushed against the dev branch
-  deploy-to-dev:
+  deploy:
     needs: build
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref_name == 'dev'
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
-      
+
+      - name: Set environment
+        if: github.event_name == 'push' && github.ref_name == 'dev'
+          env:
+            environment: dev
+        if: github.event.pull_request.merged == true && github.ref_name == 'qa'
+          env:
+            environment: qa
+
       - name: Use local deploy-to-cloud-hub action
         uses: ./.github/actions/deploy-to-cloud-hub
         with:
           username: ${{ secrets.ANYPOINT_PLATFORM_USERNAME }}
           password: ${{ secrets.ANYPOINT_PLATFORM_PASSWORD }}
-          environment: "dev"
-  
-  # Runs this job with each new pull-request merged against the qa branch
-  deploy-to-qa:
-    needs: build
-    runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == true && github.ref_name == 'qa'
-    steps:
-      - name: Check out repository
-        uses: actions/checkout@v4
-      
-      - name: Use local deploy-to-cloud-hub action
-        uses: ./.github/actions/deploy-to-cloud-hub
-        with:
-          username: ${{ secrets.ANYPOINT_PLATFORM_USERNAME }}
-          password: ${{ secrets.ANYPOINT_PLATFORM_PASSWORD }}
-          environment: "qa"
+          environment: "$environment"

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -56,13 +56,15 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v4
 
-      - name: Set environment
+      - name: Set DEV environment
         if: github.event_name == 'push' && github.ref_name == 'dev'
-          env:
-            environment: dev
+        env:
+          environment: dev
+      
+      - name: Set QA environment
         if: github.event.pull_request.merged == true && github.ref_name == 'qa'
-          env:
-            environment: qa
+        env:
+          environment: qa
 
       - name: Use local deploy-to-cloud-hub action
         uses: ./.github/actions/deploy-to-cloud-hub

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -57,11 +57,13 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set DEV environment
+        uses: actions/cache@v4
         if: github.event_name == 'push' && github.ref_name == 'dev'
         env:
           environment: dev
       
       - name: Set QA environment
+        uses: actions/cache@v4
         if: github.event.pull_request.merged == true && github.ref_name == 'qa'
         env:
           environment: qa

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -60,6 +60,11 @@ jobs:
         run: |
           if [[ "${{ github.event_name }}" == "push" && "${{ github.ref_name }}" == "dev" ]]; then
             echo "environment=dev" >> $GITHUB_ENV
+          elif [[ "${{ github.event.pull_request.merged }}" == "true" && "${{ github.ref_name }}" == "qa" ]]; then
+            echo "environment=qa" >> $GITHUB_ENV
+          else
+            echo "Skipping deployment"
+            exit 0
           fi
         shell: bash
           


### PR DESCRIPTION
- **Removed deploy-to-deve and deploy-to-qa jobs, not use only one deploy job.**
- **Fix identeation when declaring the env.environment var.**
- **Add uses to all steps inside the deploy job.**
- **Add run function to the Set target environment step.**
- **Change the way of reading the var from GITHUB_ENV. Also print env.environment var to see the content.**
- **Add condition to match the QA env.**
